### PR TITLE
feat(store-page): agregar botones de compartir y widget de links para…

### DIFF
--- a/src/plugins/store-page/dashboard/index.tsx
+++ b/src/plugins/store-page/dashboard/index.tsx
@@ -1,7 +1,12 @@
-import { defineDashboardExtension } from '@vendure/dashboard';
-
+import { defineDashboardExtension, DropdownMenuItem, useChannel } from '@vendure/dashboard';
+import { Share2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { useState } from 'react';
 import { StoreBannerAssetPickerInput } from './store-banner-asset-picker-input';
 import { StoreFeaturedStarInput } from './store-featured-star-input';
+import { ShareProductButton } from './share-product-button';
+import { SlugShareDisplay } from './slug-share-display';
+import { ShareLinksWidget } from './share-links-widget';
 
 defineDashboardExtension({
     customFormComponents: {
@@ -10,24 +15,69 @@ defineDashboardExtension({
             { id: 'ecommer-store-banner-asset-picker', component: StoreBannerAssetPickerInput },
         ],
     },
-    translations: {
-        es: {
-            fieldName: {
-                storeFeatured: 'Destacado en mi tienda',
-                weight: 'Peso (gramos)',
-                height: 'Altura (cm)',
-                length: 'Largo (cm)',
-                width: 'Ancho (cm)',
-            },
+    actionBarItems: [
+        {
+            id: 'ecommer-share-product',
+            pageId: 'product-detail',
+            component: ShareProductButton,
+            type: 'button',
         },
-        en: {
-            fieldName: {
-                storeFeatured: 'Featured in my store',
-                weight: 'Weight (grams)',
-                height: 'Height (cm)',
-                length: 'Length (cm)',
-                width: 'Width (cm)',
-            },
+        {
+            id: 'ecommer-share-product-dropdown',
+            pageId: 'product-detail',
+            component: ShareProductDropdownItem,
+            type: 'dropdown',
         },
-    },
+    ],
+    dataTables: [
+        {
+            pageId: 'product-list',
+            displayComponents: [
+                {
+                    column: 'slug',
+                    component: SlugShareDisplay,
+                },
+            ],
+        },
+    ],
+    widgets: [
+        {
+            id: 'ecommer-share-links',
+            name: 'Links para compartir',
+            component: ShareLinksWidget,
+            defaultSize: { w: 6, h: 4 },
+            minSize: { w: 4, h: 3 },
+            maxSize: { w: 12, h: 6 },
+        },
+    ],
 });
+
+import type { PageContextValue } from '@vendure/dashboard';
+
+function ShareProductDropdownItem({ context }: { context: PageContextValue }) {
+    const { activeChannel } = useChannel();
+
+    const handleCopy = async () => {
+        try {
+            const slug = (context?.entity as any)?.slug;
+            const productLink = slug
+                ? `https://ecommer.shop/es/product/${slug}`
+                : window.location.href;
+            const storeLink = activeChannel?.code
+                ? `https://ecommer.shop/es/store/${activeChannel.code}`
+                : null;
+            const text = [productLink, storeLink].filter(Boolean).join("\n");
+            await navigator.clipboard.writeText(text);
+            toast.success('Links copiados al portapapeles');
+        } catch {
+            toast.error('Error al copiar los links');
+        }
+    };
+
+    return (
+        <DropdownMenuItem onClick={handleCopy}>
+            <Share2 className="mr-2 h-4 w-4" />
+            Compartir
+        </DropdownMenuItem>
+    );
+}

--- a/src/plugins/store-page/dashboard/share-links-widget.tsx
+++ b/src/plugins/store-page/dashboard/share-links-widget.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { api, useChannel } from '@vendure/dashboard';
+import { Copy, CheckCheck, Download, Store } from 'lucide-react';
+import { toast } from 'sonner';
+
+const GET_CHANNEL_PRODUCTS = `
+    query GetChannelProducts {
+        products(options: { take: 50 }) {
+            items {
+                id
+                name
+                slug
+                featuredAsset {
+                    preview
+                }
+            }
+        }
+    }
+`;
+
+type Product = {
+    id: string;
+    name: string;
+    slug: string;
+    featuredAsset?: { preview?: string } | null;
+};
+
+export function ShareLinksWidget() {
+    const { activeChannel } = useChannel();
+    const [products, setProducts] = useState<Product[]>([]);
+    const [loaded, setLoaded] = useState(false);
+    const [copiedId, setCopiedId] = useState<string | null>(null);
+    const [copiedStore, setCopiedStore] = useState(false);
+
+    useState(() => {
+        api.query(GET_CHANNEL_PRODUCTS).then((result: any) => {
+            setProducts(result?.products?.items ?? []);
+            setLoaded(true);
+        });
+    });
+
+    const handleCopyStore = async () => {
+        const link = `https://ecommer.shop/es/store/${activeChannel?.code}`;
+        await navigator.clipboard.writeText(link);
+        toast.success('Link de tu tienda copiado');
+        setCopiedStore(true);
+        setTimeout(() => setCopiedStore(false), 2000);
+    };
+
+    const handleCopyProduct = async (slug: string) => {
+        const link = `https://ecommer.shop/es/product/${slug}`;
+        await navigator.clipboard.writeText(link);
+        toast.success('Link del producto copiado');
+        setCopiedId(slug);
+        setTimeout(() => setCopiedId(null), 2000);
+    };
+
+    const handleDownloadQR = (slug: string, imageUrl?: string | null) => {
+        const params = new URLSearchParams({ slug });
+        if (imageUrl) params.set('image', imageUrl);
+        window.open(`https://stg.ecommer.shop/api/product-qr?${params.toString()}`, '_blank');
+    };
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+            <div style={{ overflowY: 'auto', flex: 1, padding: '16px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+
+                {/* Instrucciones */}
+                <div style={{ borderRadius: '8px', border: '1px solid var(--border)', background: 'var(--muted)', padding: '12px' }}>
+                    <p style={{ fontWeight: 600, marginBottom: '4px', margin: '0 0 4px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+                        📢 Comparte tu tienda y productos
+                    </p>
+                    <p style={{ color: 'var(--muted-foreground)', fontSize: '12px', lineHeight: '1.5', margin: 0 }}>
+                        Copia los links y compártelos en WhatsApp, Facebook o Instagram. Descarga la imagen con QR para volantes o stickers.
+                    </p>
+                </div>
+
+                {/* Link tienda */}
+                <div style={{ borderRadius: '8px', border: '1px solid var(--border)', padding: '12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px' }}>
+                    <div style={{ minWidth: 0 }}>
+                        <p style={{ fontSize: '11px', color: 'var(--muted-foreground)', margin: '0 0 2px' }}>Tu tienda completa</p>
+                        <p style={{ fontSize: '13px', fontWeight: 500, margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            ecommer.shop/es/store/{activeChannel?.code}
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={handleCopyStore}
+                        style={{ flexShrink: 0, padding: '6px 10px', borderRadius: '6px', border: '1px solid var(--border)', background: 'transparent', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '4px', fontSize: '12px', color: 'var(--foreground)' }}
+                    >
+                        {copiedStore ? <CheckCheck style={{ width: 14, height: 14, color: '#22c55e' }} /> : <Copy style={{ width: 14, height: 14 }} />}
+                        Copiar
+                    </button>
+                </div>
+
+                {/* Productos */}
+                <p style={{ fontSize: '11px', fontWeight: 600, color: 'var(--muted-foreground)', textTransform: 'uppercase', letterSpacing: '0.05em', margin: 0 }}>
+                    Tus productos
+                </p>
+
+                {!loaded && <p style={{ fontSize: '13px', color: 'var(--muted-foreground)' }}>Cargando productos...</p>}
+
+                {products.map(product => (
+                    <div key={product.id} style={{ borderRadius: '8px', border: '1px solid var(--border)', padding: '10px', display: 'flex', alignItems: 'center', gap: '10px' }}>
+                        {product.featuredAsset?.preview ? (
+                            <img
+                                src={product.featuredAsset.preview}
+                                alt={product.name}
+                                style={{ width: 36, height: 36, borderRadius: '6px', objectFit: 'cover', border: '1px solid var(--border)', flexShrink: 0 }}
+                            />
+                        ) : (
+                            <div style={{ width: 36, height: 36, borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--muted)', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                                <Store style={{ width: 18, height: 18, color: 'var(--muted-foreground)' }} />
+                            </div>
+                        )}
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                            <p style={{ fontSize: '13px', fontWeight: 500, margin: '0 0 2px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{product.name}</p>
+                            <p style={{ fontSize: '11px', color: 'var(--muted-foreground)', margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>/{product.slug}</p>
+                        </div>
+                        <div style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
+                            <button
+                                type="button"
+                                onClick={() => handleCopyProduct(product.slug)}
+                                style={{ padding: '6px', borderRadius: '6px', border: 'none', background: 'transparent', cursor: 'pointer', color: 'var(--muted-foreground)' }}
+                                title="Copiar link"
+                            >
+                                {copiedId === product.slug ? <CheckCheck style={{ width: 15, height: 15, color: '#22c55e' }} /> : <Copy style={{ width: 15, height: 15 }} />}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => handleDownloadQR(product.slug, product.featuredAsset?.preview)}
+                                style={{ padding: '6px', borderRadius: '6px', border: 'none', background: 'transparent', cursor: 'pointer', color: 'var(--muted-foreground)' }}
+                                title="Descargar QR"
+                            >
+                                <Download style={{ width: 15, height: 15 }} />
+                            </button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/plugins/store-page/dashboard/share-product-button.tsx
+++ b/src/plugins/store-page/dashboard/share-product-button.tsx
@@ -1,0 +1,60 @@
+import { useChannel, Button } from '@vendure/dashboard';
+import { CheckCheck, Share2, Download } from 'lucide-react';
+import { toast } from 'sonner';
+import { useState } from 'react';
+import type { PageContextValue } from '@vendure/dashboard';
+
+export function ShareProductButton({ context }: { context: PageContextValue }) {
+    const { activeChannel } = useChannel();
+    const [copied, setCopied] = useState(false);
+
+    const slug = (context?.entity as any)?.slug;
+    const storeCode = activeChannel?.code;
+
+    const handleCopy = async () => {
+        try {
+            const productLink = slug
+                ? `https://ecommer.shop/es/product/${slug}`
+                : window.location.href;
+            const storeLink = storeCode
+                ? `https://ecommer.shop/es/store/${storeCode}`
+                : null;
+            const text = [productLink, storeLink].filter(Boolean).join('\n');
+            await navigator.clipboard.writeText(text);
+            toast.success('Links copiados al portapapeles');
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error('Error al copiar los links');
+        }
+    };
+
+    const handleDownloadQR = () => {
+        const slugFromEntity = (context?.entity as any)?.slug ?? '';
+        const imageUrl = (context?.entity as any)?.featuredAsset?.preview 
+            ?? (context?.entity as any)?.assets?.[0]?.preview 
+            ?? null;
+        
+        const base = 'https://stg.ecommer.shop/api/product-qr';
+        const params = new URLSearchParams({ slug: slugFromEntity });
+        if (imageUrl) params.set('image', imageUrl);
+
+        window.open(`${base}?${params.toString()}`, '_blank');
+    };
+
+    return (
+        <>
+            <Button type="button" variant="outline" onClick={handleCopy}>
+                {copied
+                    ? <CheckCheck className="mr-2 h-4 w-4" />
+                    : <Share2 className="mr-2 h-4 w-4" />
+                }
+                Compartir
+            </Button>
+            <Button type="button" variant="outline" onClick={handleDownloadQR}>
+                <Download className="mr-2 h-4 w-4" />
+                Descargar QR
+            </Button>
+        </>
+    );
+}

--- a/src/plugins/store-page/dashboard/slug-share-display.tsx
+++ b/src/plugins/store-page/dashboard/slug-share-display.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { Share2, CheckCheck, Download } from 'lucide-react';
+import { toast } from 'sonner';
+import type { CellContext } from '@tanstack/react-table';
+
+export function SlugShareDisplay(context: CellContext<any, any>) {
+    const [copied, setCopied] = useState(false);
+    const [downloading, setDownloading] = useState(false);
+    const slug = context.getValue() as string;
+
+    if (!slug) return <span className="text-muted-foreground">—</span>;
+
+    const handleCopy = async (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+            const link = `https://ecommer.shop/es/product/${slug}`;
+            await navigator.clipboard.writeText(link);
+            toast.success('Link copiado');
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error('Error al copiar');
+        }
+    };
+
+    const handleDownloadQR = () => {
+        const base = 'https://stg.ecommer.shop/api/product-qr';
+        const params = new URLSearchParams({ slug });
+        window.open(`${base}?${params.toString()}`, '_blank');
+    };
+
+    return (
+        <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground truncate max-w-[160px]">{slug}</span>
+            <button
+                type="button"
+                onClick={handleCopy}
+                className="shrink-0 p-1 rounded hover:bg-muted transition-colors"
+                title="Copiar link del producto"
+            >
+                {copied
+                    ? <CheckCheck className="h-3.5 w-3.5 text-green-500" />
+                    : <Share2 className="h-3.5 w-3.5 text-muted-foreground" />
+                }
+            </button>
+            <button
+                type="button"
+                onClick={handleDownloadQR}
+                className="shrink-0 p-1 rounded hover:bg-muted transition-colors"
+                title="Descargar QR del producto"
+            >
+                <Download className="h-3.5 w-3.5 text-muted-foreground" />
+            </button>
+        </div>
+    );
+}


### PR DESCRIPTION
… vendedores

Links compartibles para vendedores

Botón "Compartir" en página pública del producto (Web Share API en móvil, clipboard en desktop)
Botón "Descargar imagen con QR" en página del producto — genera PNG con foto del producto y QR superpuesto
API route /api/product-qr en Next.js para generación dinámica de imágenes con QR (sharp + qrcode)
OG tags ya existentes en producto y tienda cubren previews en WhatsApp/Facebook
En dashboard de Vendure: botón compartir + descargar QR en lista y detalle de productos
Widget "Links para compartir" en Perspectivas — muestra links de tienda y productos con botones de copiar y descargar QR