### PR TITLE
fix(dashboard): modals de bulk actions se cerraban inmediatamente

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev:worker": "ts-node ./src/index-worker.ts",
         "dev": "concurrently npm:dev:*",
         "build:server": "tsc",
-        "build:dashboard": "vite build",
+        "build:dashboard": "node scripts/patch-base-ui.mjs && vite build",
         "build": "yarn run build:server && yarn run build:dashboard",
         "build:seed": "tsc && cp -R ./static ./dist/static",
         "start:server": "node ./dist/index.js",

--- a/scripts/patch-base-ui.mjs
+++ b/scripts/patch-base-ui.mjs
@@ -1,0 +1,33 @@
+import { readFileSync, writeFileSync } from 'fs';
+
+const files = [
+    'node_modules/@base-ui/react/esm/menu/item/useMenuItemCommonProps.js',
+    'node_modules/@base-ui/react/menu/item/useMenuItemCommonProps.js',
+];
+
+const patches = [
+    {
+        TARGET: `itemRef.current.click();`,
+        REPLACEMENT: `// [patch-base-ui-mouseup] segundo click removido para no cerrar modals`,
+    },
+];
+
+let totalPatched = 0;
+for (const file of files) {
+    let content = readFileSync(file, 'utf-8');
+    let filePatchedCount = 0;
+    for (const patch of patches) {
+        if (content.includes(patch.TARGET)) {
+            content = content.replace(patch.TARGET, patch.REPLACEMENT);
+            console.log(`[patch-base-ui] patched '${patch.TARGET.substring(0, 20)}...' in ${file}`);
+            filePatchedCount++;
+        }
+    }
+    if (filePatchedCount > 0) {
+        writeFileSync(file, content);
+        totalPatched += filePatchedCount;
+    } else {
+        console.log(`[patch-base-ui] no changes needed for ${file}`);
+    }
+}
+console.log(`[patch-base-ui] done (${totalPatched} total patches applied)`);

--- a/src/vite-plugins/patch-base-ui-mouseup.ts
+++ b/src/vite-plugins/patch-base-ui-mouseup.ts
@@ -16,7 +16,7 @@ export function patchBaseUiMouseUp(): Plugin {
         enforce: 'pre' as const,
         transform(code: string, id: string) {
             const normalizedId = id.replace(/\\/g, '/');
-            if (!normalizedId.includes('@base-ui/react/esm/menu/item/useMenuItemCommonProps')) {
+if (!normalizedId.includes('useMenuItemCommonProps')) {
                 return null;
             }
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -884,7 +884,7 @@ export default defineConfig({
             
             if (!isCollapsibleTrigger && !isDropdownTrigger) {
             setTimeout(function() {
-                const closeBtn = document.querySelector('button.absolute.top-4.right-4');
+                const closeBtn = document.querySelector('[data-sidebar="sidebar"] button.absolute.top-4.right-4');
                 if (closeBtn) closeBtn.click();
             }, 50);
             }
@@ -900,7 +900,7 @@ export default defineConfig({
           if (!dropdownItem) return;
           
           setTimeout(function() {
-            const closeBtn = document.querySelector('button.absolute.top-4.right-4');
+            const closeBtn = document.querySelector('[data-sidebar="sidebar"] button.absolute.top-4.right-4');
             if (closeBtn) closeBtn.click();
           }, 100);
         }, true);


### PR DESCRIPTION
Los botones "Edit facet values" y "Duplicate" en la lista de productos 
abrían el modal y lo cerraban de inmediato.

Causa raíz: el script de cierre del sidebar en móvil usaba el selector 
`button.absolute.top-4.right-4`, que coincidía con el botón X de los 
modals, cerrándolos apenas se abrían.

Fix:
- Selector del sidebar más específico: `[data-sidebar="sidebar"] button.absolute.top-4.right-4`
- Patch de @base-ui/react para remover segundo click en onMouseUp
- Traducciones de custom fields en dashboard (storeFeatured, weight, etc.)